### PR TITLE
Add minimal embedded Play server for Java

### DIFF
--- a/performance/play-java/.gitignore
+++ b/performance/play-java/.gitignore
@@ -1,0 +1,5 @@
+.idea
+*.iml
+/project/project/
+/project/target/
+/target/

--- a/performance/play-java/README.md
+++ b/performance/play-java/README.md
@@ -1,0 +1,7 @@
+Running (Mac OS X)
+---
+
+    % brew install sbt
+    % sbt run
+
+The server will start on port 8080.

--- a/performance/play-java/build.sbt
+++ b/performance/play-java/build.sbt
@@ -1,0 +1,10 @@
+name := """play-java"""
+
+version := "1.0"
+
+scalaVersion := "2.11.7"
+
+libraryDependencies ++= Seq(
+  "com.typesafe.play" % "play-java_2.11" % "2.5.10",
+  "com.typesafe.play" %% "play-netty-server" % "2.5.10"
+)

--- a/performance/play-java/project/build.properties
+++ b/performance/play-java/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/performance/play-java/src/main/java/com/github/dpapworth/Main.java
+++ b/performance/play-java/src/main/java/com/github/dpapworth/Main.java
@@ -1,0 +1,20 @@
+package com.github.dpapworth;
+
+import play.routing.Router;
+import play.routing.RoutingDsl;
+import play.server.Server;
+
+import static play.mvc.Results.ok;
+
+public class Main {
+
+    public static void main(String[] args) {
+        Router router = new RoutingDsl().
+                GET("/").routeTo(() -> ok("Hello World!")).
+                build();
+        Server server = Server.forRouter(router, 8080);
+
+        System.out.println("Server started on " + server.httpPort());
+    }
+
+}


### PR DESCRIPTION
I've added an example for Play 2.5.10 (Java).

I tried comparing to Dropwizard on my local set up. Here are Dropwizard's results -

      Thread Stats   Avg      Stdev     Max   +/- Stdev
        Latency   136.58ms  132.19ms   1.08s    85.24%
        Req/Sec     6.53k     4.06k   34.16k    70.09%
      Latency Distribution
         50%   97.95ms
         75%  198.72ms
         90%  310.09ms
         99%  597.63ms
      784600 requests in 30.09s, 74.83MB read
    Requests/sec:  26073.36
    Transfer/sec:      2.49MB

And here are Play's results -

      Thread Stats   Avg      Stdev     Max   +/- Stdev
        Latency    32.19ms  103.75ms   1.96s    96.88%
        Req/Sec    24.85k     9.19k   40.87k    76.12%
      Latency Distribution
         50%   11.61ms
         75%   19.33ms
         90%   65.32ms
         99%  380.39ms
      2909967 requests in 30.10s, 358.00MB read
      Socket errors: connect 0, read 2, write 0, timeout 55
    Requests/sec:  96662.50
    Transfer/sec:     11.89MB

There seems to be an occasional issue with socket errors, and I've not been able to diagnose the cause. It may simply be how the server responds to excessive load. :(