### PR TITLE
disable session resolution on Act testbed

### DIFF
--- a/performance/actframework/src/main/java/demo/Example.java
+++ b/performance/actframework/src/main/java/demo/Example.java
@@ -3,6 +3,7 @@ package demo;
 import act.Version;
 import act.boot.app.RunApp;
 import org.osgl.mvc.annotation.GetAction;
+import org.osgl.mvc.annotation.SessionFree;
 
 /**
  * The simple hello world app.
@@ -14,6 +15,7 @@ import org.osgl.mvc.annotation.GetAction;
 public class Example {
 
     @GetAction
+    @SessionFree
     public String home() {
         return "Hello World!";
     }

--- a/performance/spark/src/main/java/Example.java
+++ b/performance/spark/src/main/java/Example.java
@@ -5,6 +5,6 @@ import static spark.Spark.*;
 
 public class Example {
     public static void main(String[] args) {
-        get("/", (req, res) -> "Hello World");
+        get("/", (req, res) -> "Hello World!");
     }
 }


### PR DESCRIPTION
Act by default try to resolve session cookie from request. This updates disable this behavior and should improve Act's benchmark result